### PR TITLE
update id creation for div container according chosen 1.0

### DIFF
--- a/chosenImage/chosenImage.jquery.js
+++ b/chosenImage/chosenImage.jquery.js
@@ -19,7 +19,11 @@
             // 2. Execute chosen plugin
             $select.chosen(options);
 
-            var  chzn      = '#' + $select.attr('id') + '_chzn',
+            // 2.1 update (or create) div.chzn-container id
+            var chzn_id = $select.attr('id').length ? $select.attr('id').replace(/[^\w]/g, '_') : this.generate_field_id();
+            chzn_id += "_chzn";
+
+            var  chzn      = '#' + chzn_id,            
                 $chzn      = $(chzn).addClass('chznImage-container');
 
 


### PR DESCRIPTION
Hi, 

I modified the way to create de div (containing list value)  id. 
According chosen plugin 1.0 : 
- You need to remplace - chars by _ chars
- You need to create an id if it doesn't exist

Help to improve your nice plugin for images.

Yassine.
